### PR TITLE
Uninstall LFS and convert all images out of Large Media storage

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,3 @@
 # Linguist
 *.nvss linguist-language=Less
 
-# Git LFS
-*.png filter=lfs diff=lfs merge=lfs -text
-*.jpg filter=lfs diff=lfs merge=lfs -text

--- a/.lfsconfig
+++ b/.lfsconfig
@@ -1,2 +1,0 @@
-[lfs]
-	url = https://dbba7c83-eef4-45d1-9abb-e8180f0bf0a0.netlify.app/.netlify/large-media

--- a/assets/images/backgrounds/apis-background.jpg
+++ b/assets/images/backgrounds/apis-background.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:48066b51a6fb3829f316b01734e1ae85b72e5e13f338cab99db2ac9435d4823c
-size 82679

--- a/assets/images/backgrounds/news-background.jpg
+++ b/assets/images/backgrounds/news-background.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4f2d54a7aae9de794485b6fbcfbaf4a6c3b73897a8a4602bf8415f5157624046
-size 83048

--- a/assets/images/backgrounds/projects-background.jpg
+++ b/assets/images/backgrounds/projects-background.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:20700307e9c47f4eb2ebdde0ccaee0f5af2f3f5c234e7d6607b61cf6187eb681
-size 84886

--- a/assets/images/backgrounds/self-background.jpg
+++ b/assets/images/backgrounds/self-background.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:00a050655b9223993fef0550a78fe19b3763f11b855ddf466153a46b121742ec
-size 178740

--- a/assets/images/backgrounds/tools-background.jpg
+++ b/assets/images/backgrounds/tools-background.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ab6c892b686fa6cc4f0e21ed71c4a595359182bd2d57b63a473866e781ea9dac
-size 178235

--- a/assets/images/icons/copy.png
+++ b/assets/images/icons/copy.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c8622cfef1b304759b3d7c9a3946c590af3c50d403735206029fac9eef0089bd
-size 283

--- a/assets/images/icons/download.png
+++ b/assets/images/icons/download.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:eeafc1623818665f200aa8fdaa92628a855acddb71ef10bf6030189e1804bb25
-size 372

--- a/assets/images/icons/menu.png
+++ b/assets/images/icons/menu.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f3f0337c13485fcf80664d869fe05869167a2c14fd242aa1f3ab33b0a18042e8
-size 183

--- a/assets/images/icons/rss.png
+++ b/assets/images/icons/rss.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4271c2f64a8bc6c30c3356fa14e11962f9b242ca95d165a252e7818731435f00
-size 540

--- a/assets/images/icons/search.png
+++ b/assets/images/icons/search.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2caf87d927bb8a3fe1b34d915f919a2434b297e7b7bf015e8a9078d8e81d44db
-size 585

--- a/assets/images/icons/sync.png
+++ b/assets/images/icons/sync.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ae53673e0d48c4f11674f836980cf400a74237a8e552c429e0ac06f2476d2e9d
-size 649

--- a/assets/images/logos/n.png
+++ b/assets/images/logos/n.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e54e8788b899fa46ab8dcc1b1b7f1909eb8ba29fc171c268ece58c0be6618376
-size 377226

--- a/assets/images/logos/n4b.png
+++ b/assets/images/logos/n4b.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9b8015e48f54790a9020f32c6ff45b341c62eb20e915a4ba4480eb099232759e
-size 171436

--- a/assets/images/logos/nixinova-news.png
+++ b/assets/images/logos/nixinova-news.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8b95ec9fa156e59252141ddc91982a45271ac4aa729b1d6185388b021f9789d7
-size 151911

--- a/assets/images/logos/nixinova.png
+++ b/assets/images/logos/nixinova.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4516581d013f1fff727ef078fa8bda649998ede7d622c18a8ce192429666149c
-size 37010

--- a/assets/images/minecraft/maps/kitpvp.jpg
+++ b/assets/images/minecraft/maps/kitpvp.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3e58115f9f6c8ee1e0201662b0412dc3ed58f02221613802a54308bc223fdb83
-size 308167

--- a/assets/images/minecraft/maps/musical-blocks.jpg
+++ b/assets/images/minecraft/maps/musical-blocks.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:81d1ef37869894e8689db83ef9204b65cd0616a6724b7601666bc6f54f1dfc01
-size 251506

--- a/assets/images/minecraft/maps/skywars.jpg
+++ b/assets/images/minecraft/maps/skywars.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3ed5f4e003a1361dcd253dfddf024e89e905fed53927e1707b72e6695f0fe8a8
-size 184016

--- a/assets/images/minecraft/resource-packs/easter-mash-up.jpg
+++ b/assets/images/minecraft/resource-packs/easter-mash-up.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d95977d4e01685a884889d8cf8a8da2ea79b4db2149d0e6ac9e3eac1a3cd7dec
-size 103113

--- a/assets/images/minecraft/resource-packs/endercreeper.jpg
+++ b/assets/images/minecraft/resource-packs/endercreeper.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b1f8bf09a39844e3c91c3e1003ae0646fdb73fd5dc72426e9465a933a3997d96
-size 35975

--- a/assets/images/minecraft/resource-packs/nixinova-mash-up.jpg
+++ b/assets/images/minecraft/resource-packs/nixinova-mash-up.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:944928c7f9a2c8fc2d573baf74f4c1305e95991e34deeb531a9250dc1ac642d0
-size 160336

--- a/assets/images/mineo/0.0.1.png
+++ b/assets/images/mineo/0.0.1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0d51a93681103870a158b9c290c30ada6f2495aaaa547d3f15956baabc0be5e8
-size 12321

--- a/assets/images/mineo/0.0.2.png
+++ b/assets/images/mineo/0.0.2.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4e79a6f3e4aa84883c1ff9807aff47bb4ca1d2d7388d9fcf85902a5d3514a3d5
-size 13552

--- a/assets/images/mineo/0.0.3.png
+++ b/assets/images/mineo/0.0.3.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1c081bb7b96fdcf253ab20b2b3982fabdbf48434ce3fbf83e02aa363bb8f2a9c
-size 28281

--- a/assets/images/mineo/0.0.4.png
+++ b/assets/images/mineo/0.0.4.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6a2d2a810e45a94fa57cdc814bf679030c60c01b3201e8f3f6e27f7e7f357747
-size 191472

--- a/assets/images/mineo/0.0.5.png
+++ b/assets/images/mineo/0.0.5.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:691b74148d918010630bcfb13a27e00f0bc7c949c6ab503ac06738516f2be00d
-size 92052

--- a/assets/images/mineo/0.0.6.png
+++ b/assets/images/mineo/0.0.6.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a9f12c4436673086b20b99fabe5f447f090e0edad6f10c8a90ab1f8c9e70e5c7
-size 161490

--- a/assets/images/mineo/0.0.7.png
+++ b/assets/images/mineo/0.0.7.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:62af2f631a233a3bf597506f0f99689f7ceeda09f71a9a631adfb99d143ee103
-size 173240

--- a/assets/images/mineo/0.1.0.png
+++ b/assets/images/mineo/0.1.0.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7746930bd33bbfdae0178968aa82b6b0171640067b3917ae1a3104bce9021159
-size 86951

--- a/assets/images/mineo/0.1.1.png
+++ b/assets/images/mineo/0.1.1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dae9284d8e8879c640f6944fb708eca5c956f3b9741062568897a1c7f4e68d82
-size 137714

--- a/assets/images/mineo/0.1.2.png
+++ b/assets/images/mineo/0.1.2.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b7d48065d760bdac60c20080355f936240674d8a8c757bc2ae3fe787549d89a8
-size 79252

--- a/assets/images/mineo/0.1.3.png
+++ b/assets/images/mineo/0.1.3.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1f3dc04164d36975e22c84200966dd10c948a19b171e8a80512c9580f4f11a46
-size 205876

--- a/assets/images/mineo/0.1.4.png
+++ b/assets/images/mineo/0.1.4.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b8182f3c3c2bbdb219f97457f4d26717e06eff204b7a8bba192ce51f9a33a54c
-size 101930

--- a/assets/images/mineo/0.1.5.png
+++ b/assets/images/mineo/0.1.5.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:803691fc37b8313fc7ad2df204ccfc8afde94b08a477b1550d0a37efe41ff68b
-size 94866

--- a/assets/images/mineo/0.2.0.png
+++ b/assets/images/mineo/0.2.0.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:272c3d6d81fd225f6071dcb94dc085a26972980d36c8b48f47f58c48499e8a22
-size 121996

--- a/assets/images/mineo/0.2.1.png
+++ b/assets/images/mineo/0.2.1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cef78d65c4ed1cce1c602509f72f6669d389857238cfb375cded37f0933bd8e8
-size 126053

--- a/assets/images/mineo/0.2.2.png
+++ b/assets/images/mineo/0.2.2.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b3ae69bb3fcbd2da82cf387525e7e7244b8942e12d77bb097194a52727105e8b
-size 105868

--- a/assets/images/mineo/0.2.3.png
+++ b/assets/images/mineo/0.2.3.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0b6701d1f685b996be4dedafcc9ea91a68009db0462e33a48ea170350dde42a8
-size 152562

--- a/assets/images/mineo/0.2.4.png
+++ b/assets/images/mineo/0.2.4.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:49e3a7a823e2445e1898a67cd0f673d0e01b8eba5f5e7527827ff67c534ed622
-size 62231

--- a/assets/images/mineo/0.3.0.png
+++ b/assets/images/mineo/0.3.0.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ecd864a4a5755004d9470fecb74cba26e4e86f5bf08a0c20a48f65b5b6369f51
-size 107413

--- a/assets/images/mineo/0.4.0.png
+++ b/assets/images/mineo/0.4.0.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:79c9be8e926b9a966a3cef089f11beb0a529943a3743cd64d6310ae92e8d176a
-size 216958

--- a/assets/images/mineo/0.4.1.png
+++ b/assets/images/mineo/0.4.1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:16a639b5de2e0d56af25a443c0abc81b2232e2ed0f38d32eb0c1dce67258764e
-size 182270

--- a/assets/images/mineo/0.4.2.png
+++ b/assets/images/mineo/0.4.2.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ce4a1b4c79436a4223a44636fa3dca711f63254d53e3f4da27c173cd89325800
-size 72790

--- a/meta/_redirects
+++ b/meta/_redirects
@@ -3,6 +3,7 @@
 
 # Redirecters
 /redirect/novasheets/*              https://novasheets.js.org/:splat
+/assets/images/*                    https://images.nixinova.com/:splat
 
 # Page moves
 /maps/*                             /downloads/minecraft/maps/:splat
@@ -17,7 +18,6 @@
 /mineo/versions                     /projects/mineo/versions
 
 # Shortcuts
-/logo/*                             /assets/images/logos/:splat
 /musical-blocks                     /downloads/minecraft/maps/musical-blocks
 /kitpvp                             /downloads/minecraft/maps/kitpvp
 /skywars                            /downloads/minecraft/maps/skywars


### PR DESCRIPTION
Images have been moved to the https://images.nixinova.com subdomain stored on branch [images](https://github.com/Nixinova/Website/tree/images).